### PR TITLE
Clarify that contain prevents navigation.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -105,13 +105,19 @@ Values have the following meanings:
 <dl dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" dfn-type="value">
   <dt><dfn>contain</dfn>
   <dd>
-    This value indicates that the element must not perform <a>non-local boundary default actions</a>. The user agent must not perform scholl chaining to any ancestors along the <a>scroll chain</a> regardless of whether the scroll originated at this element or one of its descendants. This value must not modify the behavior of how <a>local boundary default actions</a> should behave, such as overscroll behavior and navigation guestures. 
+    This value indicates that the element must not perform <a>non-local boundary default actions</a>
+    such as scroll chaining or navigation. The user agent must not perform scroll chaining to any
+    ancestors along the <a>scroll chain</a> regardless of whether the scroll originated at this
+    element or one of its descendants. This value must not modify the behavior of how <a>local
+    boundary default actions</a> should behave, such as overscroll behavior.
   <dt><dfn>none</dfn>
   <dd>
-    This value implies the same behavior as <a>contain</a> and in addition this element must also not perform <a>local boundary default actions</a> such as showing any overscroll affordances or performing any navigation guestures.
+    This value implies the same behavior as <a>contain</a> and in addition this element must also
+    not perform <a>local boundary default actions</a> such as showing any overscroll affordances.
   <dt><dfn>auto</dfn>
   <dd>
-    This value indicates that the user agent should perform the usual <a>boundary default action</a> with respect to both <a>scroll chaining</a>, overscroll and navigation guestures.
+    This value indicates that the user agent should perform the usual <a>boundary default action</a>
+    with respect to <a>scroll chaining</a>, overscroll and navigation gestures.
 </dl>
 
 Note: In the case where a user agent does not implement scroll chaining and overscroll affordances, these values will have no side effects for a compliant implementation.

--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@
 		font-style: normal;
 	}
 	dt dfn code, code.idl {
-		font-size: normal;
+		font-size: medium;
 	}
 	dfn var {
 		font-style: normal;
@@ -1176,7 +1176,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 5bd73bb15eb04ad9f7d1a57f012e9ee6eca5a765" name="generator">
+  <meta content="Bikeshed version 872fb1bbb75c7b4e192209b354c34f634da3ac0d" name="generator">
   <link href="https://wicg.github.io/scroll-boundary-behavior/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1366,11 +1366,13 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">CSS Scroll Boundary Behavior Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-05-08">8 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-09-07">7 September 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/scroll-boundary-behavior/">https://wicg.github.io/scroll-boundary-behavior/</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/majido/scroll-boundary-behavior/issues/">GitHub</a>
      <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bgirard@fb.com">Benoit Girard</a> (<span class="p-org org">Facebook</span>)
     </dl>
@@ -1520,11 +1522,15 @@ document but does not want to prevent native overscroll affordances.
    <p>Values have the following meanings:</p>
    <dl>
     <dt><dfn class="css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-contain">contain<a class="self-link" href="#valdef-scroll-boundary-behavior-contain"></a></dfn> 
-    <dd> This value indicates that the element must not perform <a data-link-type="dfn" href="#non-local-boundary-default-action" id="ref-for-non-local-boundary-default-action-1">non-local boundary default actions</a>. The user agent must not perform scholl chaining to any ancestors along the scroll chain regardless of whether the scroll originated at this element or one of its descendants. This value must not modify the behavior of how <a data-link-type="dfn" href="#local" id="ref-for-local-1">local boundary default actions</a> should behave, such as overscroll behavior and navigation guestures. 
+    <dd> This value indicates that the element must not perform <a data-link-type="dfn" href="#non-local-boundary-default-action" id="ref-for-non-local-boundary-default-action-1">non-local boundary default actions</a> such as scroll chaining or navigation. The user agent must not perform scroll chaining to any
+    ancestors along the <a data-link-type="dfn" href="#scroll-chain" id="ref-for-scroll-chain-3">scroll chain</a> regardless of whether the scroll originated at this
+    element or one of its descendants. This value must not modify the behavior of how <a data-link-type="dfn" href="#local" id="ref-for-local-1">local
+    boundary default actions</a> should behave, such as overscroll behavior. 
     <dt><dfn class="css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-none">none<a class="self-link" href="#valdef-scroll-boundary-behavior-none"></a></dfn> 
-    <dd> This value implies the same behavior as <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> and in addition this element must also not perform <a data-link-type="dfn" href="#local" id="ref-for-local-2">local boundary default actions</a> such as showing any overscroll affordances or performing any navigation guestures. 
+    <dd> This value implies the same behavior as <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> and in addition this element must also
+    not perform <a data-link-type="dfn" href="#local" id="ref-for-local-2">local boundary default actions</a> such as showing any overscroll affordances. 
     <dt><dfn class="dfn-paneled css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-auto">auto</dfn> 
-    <dd> This value indicates that the user agent should perform the usual <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action-4">boundary default action</a> with respect to both <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining-3">scroll chaining</a>, overscroll and navigation guestures. 
+    <dd> This value indicates that the user agent should perform the usual <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action-4">boundary default action</a> with respect to <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining-3">scroll chaining</a>, overscroll and navigation gestures. 
    </dl>
    <p class="note" role="note"><span>Note:</span> In the case where a user agent does not implement scroll chaining and overscroll affordances, these values will have no side effects for a compliant implementation.</p>
    <p class="note" role="note"><span>Note:</span> Programmatic scrolling is clamped and can not trigger any <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action-5">boundary default actions</a>.</p>
@@ -1739,6 +1745,17 @@ document but does not want to prevent native overscroll affordances.
       <th scope="col">Com­puted value
     <tbody>
      <tr>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior">scroll-boundary-behavior</a>
+      <td>contain | none | auto
+      <td>auto
+      <td>scroll container elements
+      <td>no
+      <td>n/a
+      <td>visual
+      <td>no
+      <td>per grammar
+      <td>see individual properties
+     <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior-x">scroll-boundary-behavior-x</a>
       <td>contain | none | auto
       <td>auto
@@ -1760,17 +1777,6 @@ document but does not want to prevent native overscroll affordances.
       <td>no
       <td>per grammar
       <td>see individual properties
-     <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior">scroll-boundary-behavior</a>
-      <td>contain | none | auto
-      <td>auto
-      <td>scroll container elements
-      <td>no
-      <td>n/a
-      <td>visual
-      <td>no
-      <td>per grammar
-      <td>see individual properties
    </table>
   </div>
   <aside class="dfn-panel" data-for="scroll-chaining">
@@ -1785,6 +1791,7 @@ document but does not want to prevent native overscroll affordances.
    <ul>
     <li><a href="#ref-for-scroll-chain-1">1. Introduction</a>
     <li><a href="#ref-for-scroll-chain-2">2. Scroll chaining and boundary default actions</a>
+    <li><a href="#ref-for-scroll-chain-3">4. Scroll Boundary Behavior Properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="scroll-boundary">


### PR DESCRIPTION
Existing wording suggests that to prevent navigation (a non-local action) one has to use none.
This revised new wording makes this more clear.

Fixes issue #8 