### PR TITLE
Fix link issues

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -129,7 +129,8 @@ Note: In the case where a user agent does not implement scroll chaining and over
 Note: Programmatic scrolling is clamped and can not trigger any <a>boundary default actions</a>.
 
 
-Security and Privacy Considerations
+
+Security and Privacy Considerations {#security-and-privacy}
 ===================================
 There are no known security or privacy impacts of this feature. The feature may be used to prevent
 certain native UI features such as overscroll affordances and overscroll navigations (e.g., pull-

--- a/index.bs
+++ b/index.bs
@@ -21,13 +21,11 @@ url: https://drafts.csswg.org/css-overflow-3/#scroll-container
 url: https://www.w3.org/TR/uievents/#default-action
     type: dfn; text: default action
     type: dfn; text: default actions
-url: #local
-    type: dfn; text: local boundary default action
-    type: dfn; text: local boundary default actions
 url: https://dom.spec.whatwg.org/#dom-event-preventdefault
     type: dfn; text: preventDefault
 url: https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener
     type: dfn; text: passive flag
+
 </pre>
 
 Introduction {#intro}
@@ -38,10 +36,10 @@ Introduction {#intro}
 A content author does not necessarily want <a>scroll chaining</a> to occur for all <a>scroll containers</a>. Some <a>scroll containers</a> may be part of a <a>containing block chain</a> but may serve a different logical purpose in the document and may want to prevent scrolling from continuing up the <a>scroll chain</a>. To achieve this, a content author will install event listeners without the <a>passive flag</a> set and will use <a>preventDefault</a> when there is a risk that scroll chaining will occur. This is detrimental for the following reasons:
 * The user agent may in the future introduce new input methods for scrolling that are not supported by the content author's event listeners.
 * A non passive event listener will delay scrolling because the user agent will have to wait for the result of the event listener to determine if <a>preventDefault</a> was called causing increased scroll latency.
-* When scrolling is performed near the edge of the <a>scroll boundary<a>, the <a>default action</a> may cause both scrolling to the edge of the <a>scroll container</a> and a <a>boundary default action</a>. Calling <a>preventDefault</a> will not only cancel the <a>boundary default action</a> but also the scroll to the edge of the <a>scrollport</a>.
+* When scrolling is performed near the edge of the <a>scroll boundary</a>, the <a>default action</a> may cause both scrolling to the edge of the <a>scroll container</a> and a <a>boundary default action</a>. Calling <a>preventDefault</a> will not only cancel the <a>boundary default action</a> but also the scroll to the edge of the <a>scrollport</a>.
 * The <a>default action</a> for the event may also provide additional behavior that the author does not want to cancel such as an overscroll affordance. <a>preventDefault</a> doesn't allow the content author to cancel only some of the <a>default actions</a> such as scroll chaining.
 
-Thus, it is not possible for a content author to control <a>scroll chaining</a> and overscroll in a robust, performant and forward compatible way. The <a>scroll-boundary-behavior</a> property fixes this shortcoming.
+Thus, it is not possible for a content author to control <a>scroll chaining</a> and overscroll in a robust, performant and forward compatible way. The 'scroll-boundary-behavior' property fixes this shortcoming.
 
 <pre class=example>
 A 'position: fixed' left navigation bar may not want to hand off scrolling to the
@@ -57,9 +55,14 @@ Scroll chaining and boundary default actions {#scroll-chaining-and-boundary-defa
 
 A <dfn>scroll chain</dfn> is the order in which scrolling is propagated from one <a>scroll container</a> to another.
 
-<dfn>Scroll boundary</dfn> refers to when the scroll position of a <a>scroll container</a> reaches the edge of the <a>scrollport<a>. If a scroll container has no potential to scroll, because it does not <a>overflow</a> in the direction of the scroll, the element is always considered to be at the scroll boundary. 
+<dfn>Scroll boundary</dfn> refers to when the scroll position of a <a>scroll container</a> reaches the edge of the <a>scrollport</a>. If a scroll container has no potential to scroll, because it does not <a>overflow</a> in the direction of the scroll, the element is always considered to be at the scroll boundary.
 
-<dfn>Boundary default action</dfn> refers to the user-agent-defined <a>default action</a> performed when scrolling against the edge of the <a>scrollport</a>. A <a>boundary default action</a> is said to be <dfn>local</dfn>, for example overscroll, if it is performed on the <a>scroll container</a> without interacting with the page. Conversely, a <dfn>non-local boundary default action</dfn> will interact with the page such as scroll chaining or a navigation action.
+<dfn>Boundary default action</dfn> refers to the user-agent-defined <a>default action</a> performed
+when scrolling against the edge of the <a>scrollport</a>. A <dfn>local boundary default action</dfn>
+is a <a>boundary default action</a> which is performed on the <a>scroll container</a> without
+interacting with the page, for example displaying a overscroll UI affordance. Conversely, a <dfn
+>non-local boundary default action</dfn> interacts with the page, for example scroll chaining or a
+navigation action.
 
 Overview {#overview}
 ==========================
@@ -75,8 +78,8 @@ Note: This property should provide guarantees that are, at least, as strong as <
 
 <pre class=propdef>
 Name: scroll-boundary-behavior-x, scroll-boundary-behavior-y
-Value: ''contain'' | ''none'' | ''auto''
-Initial: ''auto''
+Value: contain | none | auto
+Initial: auto
 Applies to: <a>scroll container</a> elements
 Inherited: no
 Percentages: N/A
@@ -90,8 +93,8 @@ The 'scroll-boundary-behavior-x' property specifies the behavior of the 'scroll-
 
 <pre class=propdef>
 Name: scroll-boundary-behavior
-Value: ''contain'' | ''none'' | ''auto''
-Initial: ''auto''
+Value: contain | none | auto
+Initial: auto
 Applies to: <a>scroll container</a> elements
 Inherited: no
 Media: visual
@@ -105,13 +108,20 @@ Values have the following meanings:
 <dl dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" dfn-type="value">
   <dt><dfn>contain</dfn>
   <dd>
-    This value indicates that the element must not perform <a>non-local boundary default actions</a>. The user agent must not perform scholl chaining to any ancestors along the <a>scroll chain</a> regardless of whether the scroll originated at this element or one of its descendants. This value must not modify the behavior of how <a>local boundary default actions</a> should behave, such as overscroll behavior and navigation guestures. 
+    This value indicates that the element must not perform <a>non-local boundary default actions</a>
+    such as scroll chaining or navigation. The user agent must not perform scroll chaining to any
+    ancestors along the <a>scroll chain</a> regardless of whether the scroll originated at this
+    element or one of its descendants. This value must not modify the behavior of how <a>local
+    boundary default actions</a> should behave, such as overscroll behavior.
   <dt><dfn>none</dfn>
   <dd>
-    This value implies the same behavior as <a>contain</a> and in addition this element must also not perform <a>local boundary default actions</a> such as showing any overscroll affordances or performing any navigation guestures.
+    This value implies the same behavior as <a value for=scroll-boundary-behavior>contain</a> and in
+    addition this element must also not perform <a>local boundary default actions</a> such as
+    showing any overscroll affordances.
   <dt><dfn>auto</dfn>
   <dd>
-    This value indicates that the user agent should perform the usual <a>boundary default action</a> with respect to both <a>scroll chaining</a>, overscroll and navigation guestures.
+    This value indicates that the user agent should perform the usual <a>boundary default action</a>
+    with respect to <a>scroll chaining</a>, overscroll and navigation gestures.
 </dl>
 
 Note: In the case where a user agent does not implement scroll chaining and overscroll affordances, these values will have no side effects for a compliant implementation.

--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@
 		font-style: normal;
 	}
 	dt dfn code, code.idl {
-		font-size: normal;
+		font-size: medium;
 	}
 	dfn var {
 		font-style: normal;
@@ -1176,47 +1176,47 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 5bd73bb15eb04ad9f7d1a57f012e9ee6eca5a765" name="generator">
+  <meta content="Bikeshed version aa82ed4ababc6275b796a6e8bae93f32d8a46d2d" name="generator">
   <link href="https://wicg.github.io/scroll-boundary-behavior/" rel="canonical">
 <style>/* style-md-lists */
 
-            /* This is a weird hack for me not yet following the commonmark spec
-               regarding paragraph and lists. */
-            [data-md] > :first-child {
-                margin-top: 0;
-            }
-            [data-md] > :last-child {
-                margin-bottom: 0;
-            }</style>
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}</style>
 <style>/* style-counters */
 
-            body {
-                counter-reset: example figure issue;
-            }
-            .issue {
-                counter-increment: issue;
-            }
-            .issue:not(.no-marker)::before {
-                content: "Issue " counter(issue);
-            }
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
 
-            .example {
-                counter-increment: example;
-            }
-            .example:not(.no-marker)::before {
-                content: "Example " counter(example);
-            }
-            .invalid.example:not(.no-marker)::before,
-            .illegal.example:not(.no-marker)::before {
-                content: "Invalid Example" counter(example);
-            }
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
 
-            figcaption {
-                counter-increment: figure;
-            }
-            figcaption:not(.no-marker)::before {
-                content: "Figure " counter(figure) " ";
-            }</style>
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}</style>
 <style>/* style-dfn-panel */
 
         .dfn-panel {
@@ -1256,121 +1256,123 @@ Possible extra rowspan handling
         </style>
 <style>/* style-selflinks */
 
-            .heading, .issue, .note, .example, li, dt {
-                position: relative;
-            }
-            a.self-link {
-                position: absolute;
-                top: 0;
-                left: calc(-1 * (3.5rem - 26px));
-                width: calc(3.5rem - 26px);
-                height: 2em;
-                text-align: center;
-                border: none;
-                transition: opacity .2s;
-                opacity: .5;
-            }
-            a.self-link:hover {
-                opacity: 1;
-            }
-            .heading > a.self-link {
-                font-size: 83%;
-            }
-            li > a.self-link {
-                left: calc(-1 * (3.5rem - 26px) - 2em);
-            }
-            dfn > a.self-link {
-                top: auto;
-                left: auto;
-                opacity: 0;
-                width: 1.5em;
-                height: 1.5em;
-                background: gray;
-                color: white;
-                font-style: normal;
-                transition: opacity .2s, background-color .2s, color .2s;
-            }
-            dfn:hover > a.self-link {
-                opacity: 1;
-            }
-            dfn > a.self-link:hover {
-                color: black;
-            }
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: gray;
+    color: white;
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: black;
+}
 
-            a.self-link::before            { content: "¶"; }
-            .heading > a.self-link::before { content: "§"; }
-            dfn > a.self-link::before      { content: "#"; }</style>
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }</style>
 <style>/* style-autolinks */
 
-            .css.css, .property.property, .descriptor.descriptor {
-                color: #005a9c;
-                font-size: inherit;
-                font-family: inherit;
-            }
-            .css::before, .property::before, .descriptor::before {
-                content: "‘";
-            }
-            .css::after, .property::after, .descriptor::after {
-                content: "’";
-            }
-            .property, .descriptor {
-                /* Don't wrap property and descriptor names */
-                white-space: nowrap;
-            }
-            .type { /* CSS value <type> */
-                font-style: italic;
-            }
-            pre .property::before, pre .property::after {
-                content: "";
-            }
-            [data-link-type="property"]::before,
-            [data-link-type="propdesc"]::before,
-            [data-link-type="descriptor"]::before,
-            [data-link-type="value"]::before,
-            [data-link-type="function"]::before,
-            [data-link-type="at-rule"]::before,
-            [data-link-type="selector"]::before,
-            [data-link-type="maybe"]::before {
-                content: "‘";
-            }
-            [data-link-type="property"]::after,
-            [data-link-type="propdesc"]::after,
-            [data-link-type="descriptor"]::after,
-            [data-link-type="value"]::after,
-            [data-link-type="function"]::after,
-            [data-link-type="at-rule"]::after,
-            [data-link-type="selector"]::after,
-            [data-link-type="maybe"]::after {
-                content: "’";
-            }
+.css.css, .property.property, .descriptor.descriptor {
+    color: #005a9c;
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
 
-            [data-link-type].production::before,
-            [data-link-type].production::after,
-            .prod [data-link-type]::before,
-            .prod [data-link-type]::after {
-                content: "";
-            }
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
 
-            [data-link-type=element],
-            [data-link-type=element-attr] {
-                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
-                font-size: .9em;
-            }
-            [data-link-type=element]::before { content: "<" }
-            [data-link-type=element]::after  { content: ">" }
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
 
-            [data-link-type=biblio] {
-                white-space: pre;
-            }</style>
+[data-link-type=biblio] {
+    white-space: pre;
+}</style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">CSS Scroll Boundary Behavior Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-05-08">8 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-09-07">7 September 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/scroll-boundary-behavior/">https://wicg.github.io/scroll-boundary-behavior/</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/majido/scroll-boundary-behavior/issues/">GitHub</a>
      <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bgirard@fb.com">Benoit Girard</a> (<span class="p-org org">Facebook</span>)
     </dl>
@@ -1382,9 +1384,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>This module defines <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior">scroll-boundary-behavior</a> to control the behavior when the scroll position of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> reaches the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport">scrollport</a>.
+   <p>This module defines <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior">scroll-boundary-behavior</a> to control the behavior when the scroll position of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container">scroll container</a> reaches the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport">scrollport</a>.
 
-This allows content authors to hint that the <a data-link-type="dfn" href="#boundary-default-action">boundary default actions</a>,
+This allows content authors to hint that the <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action">boundary default actions</a>,
 such as scroll chaining and overscroll, should not be triggered.</p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1424,32 +1426,35 @@ such as scroll chaining and overscroll, should not be triggered.</p>
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
    <p><em>This section is not normative.</em></p>
-   <p>A content author does not necessarily want <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining-1">scroll chaining</a> to occur for all <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll containers</a>. Some <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll containers</a> may be part of a <a data-link-type="dfn" href="https://www.w3.org/TR/css-display-3/#containing-block-chain">containing block chain</a> but may serve a different logical purpose in the document and may want to prevent scrolling from continuing up the <a data-link-type="dfn" href="#scroll-chain" id="ref-for-scroll-chain-1">scroll chain</a>. To achieve this, a content author will install event listeners without the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">passive flag</a> set and will use <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault</a> when there is a risk that scroll chaining will occur. This is detrimental for the following reasons:</p>
+   <p>A content author does not necessarily want <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining">scroll chaining</a> to occur for all <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①">scroll containers</a>. Some <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container②">scroll containers</a> may be part of a <a data-link-type="dfn" href="https://www.w3.org/TR/css-display-3/#containing-block-chain" id="ref-for-containing-block-chain">containing block chain</a> but may serve a different logical purpose in the document and may want to prevent scrolling from continuing up the <a data-link-type="dfn" href="#scroll-chain" id="ref-for-scroll-chain">scroll chain</a>. To achieve this, a content author will install event listeners without the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener" id="ref-for-dom-eventtarget-addeventlistener">passive flag</a> set and will use <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault">preventDefault</a> when there is a risk that scroll chaining will occur. This is detrimental for the following reasons:</p>
    <ul>
     <li data-md="">
      <p>The user agent may in the future introduce new input methods for scrolling that are not supported by the content author’s event listeners.</p>
     <li data-md="">
-     <p>A non passive event listener will delay scrolling because the user agent will have to wait for the result of the event listener to determine if <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault</a> was called causing increased scroll latency.</p>
+     <p>A non passive event listener will delay scrolling because the user agent will have to wait for the result of the event listener to determine if <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault①">preventDefault</a> was called causing increased scroll latency.</p>
     <li data-md="">
-     <p>When scrolling is performed near the edge of the <a data-link-type="dfn" href="#scroll-boundary" id="ref-for-scroll-boundary-1">scroll boundary</a><a data-link-type="dfn">, the </a><a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action">default action</a> may cause both scrolling to the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> and a <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action-1">boundary default action</a>. Calling <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault</a> will not only cancel the <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action-2">boundary default action</a> but also the scroll to the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport">scrollport</a>.</p>
+     <p>When scrolling is performed near the edge of the <a data-link-type="dfn" href="#scroll-boundary" id="ref-for-scroll-boundary">scroll boundary</a>, the <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action" id="ref-for-default-action">default action</a> may cause both scrolling to the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container③">scroll container</a> and a <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action①">boundary default action</a>. Calling <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault②">preventDefault</a> will not only cancel the <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action②">boundary default action</a> but also the scroll to the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport①">scrollport</a>.</p>
     <li data-md="">
-     <p>The <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action">default action</a> for the event may also provide additional behavior that the author does not want to cancel such as an overscroll affordance. <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault</a> doesn’t allow the content author to cancel only some of the <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action">default actions</a> such as scroll chaining.</p>
+     <p>The <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action" id="ref-for-default-action①">default action</a> for the event may also provide additional behavior that the author does not want to cancel such as an overscroll affordance. <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault③">preventDefault</a> doesn’t allow the content author to cancel only some of the <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action" id="ref-for-default-action②">default actions</a> such as scroll chaining.</p>
    </ul>
-   <p>Thus, it is not possible for a content author to control <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining-2">scroll chaining</a> and overscroll in a robust, performant and forward compatible way. The <a data-link-type="dfn">scroll-boundary-behavior</a> property fixes this shortcoming.</p>
+   <p>Thus, it is not possible for a content author to control <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining①">scroll chaining</a> and overscroll in a robust, performant and forward compatible way. The <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior①">scroll-boundary-behavior</a> property fixes this shortcoming.</p>
 <pre class="example" id="example-c20a9060"><a class="self-link" href="#example-c20a9060"></a>A 'position: fixed' left navigation bar may not want to hand off scrolling to the
 document but does not want to prevent native overscroll affordances.
 </pre>
    <h2 class="heading settled" data-level="2" id="scroll-chaining-and-boundary-default-actions"><span class="secno">2. </span><span class="content">Scroll chaining and boundary default actions</span><a class="self-link" href="#scroll-chaining-and-boundary-default-actions"></a></h2>
    <p><em>Operating Systems have rules for scrolling such as scroll chaining and overscroll affordances. This specification does not mandate if and how scroll chaining or overscroll affordances be implemented. This specification only allows the content author to disable them if any are implemented.</em></p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="scroll-chaining">Scroll chaining</dfn> is when scrolling is propagated from one <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> to an ancestor <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> following the <a data-link-type="dfn" href="#scroll-chain" id="ref-for-scroll-chain-2">scroll chain</a>. Typically scroll chaining is performed starting at the event target recursing up the <a data-link-type="dfn" href="https://www.w3.org/TR/css-display-3/#containing-block-chain">containing block chain</a>. When a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> in this chain receives a scroll event or gesture it may act on it and/or pass it up the chain. Chaining typically occurs when the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport">scrollport</a> has reached its boundary.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="scroll-chain">scroll chain</dfn> is the order in which scrolling is propagated from one <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> to another.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="scroll-boundary">Scroll boundary</dfn> refers to when the scroll position of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> reaches the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport">scrollport</a><a data-link-type="dfn">. If a scroll container has no potential to scroll, because it does not </a><a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#overflow">overflow</a> in the direction of the scroll, the element is always considered to be at the scroll boundary.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="boundary-default-action">Boundary default action</dfn> refers to the user-agent-defined <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action">default action</a> performed when scrolling against the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport">scrollport</a>. A <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action-3">boundary default action</a> is said to be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="local">local</dfn>, for example overscroll, if it is performed on the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> without interacting with the page. Conversely, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="non-local-boundary-default-action">non-local boundary default action</dfn> will interact with the page such as scroll chaining or a navigation action.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="scroll-chaining">Scroll chaining</dfn> is when scrolling is propagated from one <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container④">scroll container</a> to an ancestor <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container⑤">scroll container</a> following the <a data-link-type="dfn" href="#scroll-chain" id="ref-for-scroll-chain①">scroll chain</a>. Typically scroll chaining is performed starting at the event target recursing up the <a data-link-type="dfn" href="https://www.w3.org/TR/css-display-3/#containing-block-chain" id="ref-for-containing-block-chain①">containing block chain</a>. When a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container⑥">scroll container</a> in this chain receives a scroll event or gesture it may act on it and/or pass it up the chain. Chaining typically occurs when the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport②">scrollport</a> has reached its boundary.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="scroll-chain">scroll chain</dfn> is the order in which scrolling is propagated from one <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container⑦">scroll container</a> to another.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="scroll-boundary">Scroll boundary</dfn> refers to when the scroll position of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container⑧">scroll container</a> reaches the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport③">scrollport</a>. If a scroll container has no potential to scroll, because it does not <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#overflow" id="ref-for-overflow">overflow</a> in the direction of the scroll, the element is always considered to be at the scroll boundary.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="boundary-default-action">Boundary default action</dfn> refers to the user-agent-defined <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action" id="ref-for-default-action③">default action</a> performed
+when scrolling against the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport④">scrollport</a>. A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="local-boundary-default-action">local boundary default action</dfn> is a <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action③">boundary default action</a> which is performed on the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container⑨">scroll container</a> without
+interacting with the page, for example displaying a overscroll UI affordance. Conversely, a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="non-local-boundary-default-action">non-local boundary default action</dfn> interacts with the page, for example scroll chaining or a
+navigation action.</p>
    <h2 class="heading settled" data-level="3" id="overview"><span class="secno">3. </span><span class="content">Overview</span><a class="self-link" href="#overview"></a></h2>
-   <p>This module introduces control over the behavior of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> element when its <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport">scrollport</a> reaches the boundary of its scroll box. It allows the content author to specify that a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> element must prevent scroll chaining and/or overscroll affordances.</p>
+   <p>This module introduces control over the behavior of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①⓪">scroll container</a> element when its <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport⑤">scrollport</a> reaches the boundary of its scroll box. It allows the content author to specify that a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①①">scroll container</a> element must prevent scroll chaining and/or overscroll affordances.</p>
    <h2 class="heading settled" data-level="4" id="scroll-boundary-behavior-properties"><span class="secno">4. </span><span class="content">Scroll Boundary Behavior Properties</span><a class="self-link" href="#scroll-boundary-behavior-properties"></a></h2>
-   <p>These properties specify how a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> element must behave when scrolling. A element that is not <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> must accept but ignore the values of this property. This property must be applied to all input methods supported by the user agent.</p>
-   <p class="note" role="note"><span>Note:</span> This property should provide guarantees that are, at least, as strong as <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault</a> for preventing both scroll chaining and overscroll. Doing otherwise would cause content authors to use <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault</a> instead.</p>
+   <p>These properties specify how a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①②">scroll container</a> element must behave when scrolling. A element that is not <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①③">scroll container</a> must accept but ignore the values of this property. This property must be applied to all input methods supported by the user agent.</p>
+   <p class="note" role="note"><span>Note:</span> This property should provide guarantees that are, at least, as strong as <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault④">preventDefault</a> for preventing both scroll chaining and overscroll. Doing otherwise would cause content authors to use <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault⑤">preventDefault</a> instead.</p>
    <table class="def propdef" data-link-for-hint="scroll-boundary-behavior-x">
     <tbody>
      <tr>
@@ -1457,13 +1462,13 @@ document but does not want to prevent native overscroll affordances.
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scroll-boundary-behavior-x">scroll-boundary-behavior-x</dfn>, <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scroll-boundary-behavior-y">scroll-boundary-behavior-y</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod"><span class="css">contain</span> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <span class="css">none</span> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="css" data-link-type="maybe" href="#valdef-scroll-boundary-behavior-auto" id="ref-for-valdef-scroll-boundary-behavior-auto-1">auto</a>
+      <td class="prod">contain <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①">|</a> auto
      <tr>
       <th>Initial:
-      <td><a class="css" data-link-type="maybe" href="#valdef-scroll-boundary-behavior-auto" id="ref-for-valdef-scroll-boundary-behavior-auto-2">auto</a>
+      <td>auto
      <tr>
       <th>Applies to:
-      <td><a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> elements
+      <td><a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①④">scroll container</a> elements
      <tr>
       <th>Inherited:
       <td>no
@@ -1483,7 +1488,7 @@ document but does not want to prevent native overscroll affordances.
       <th>Animatable:
       <td>no
    </table>
-   <p>The <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior-x" id="ref-for-propdef-scroll-boundary-behavior-x-1">scroll-boundary-behavior-x</a> property specifies the behavior of the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior-1">scroll-boundary-behavior</a> in the horizontal direction and the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior-y" id="ref-for-propdef-scroll-boundary-behavior-y-1">scroll-boundary-behavior-y</a> property specifies the handling of the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior-2">scroll-boundary-behavior</a> in the vertical direction. When scrolling is performed along both the horizontal and vertical axes at the same time, the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior-3">scroll-boundary-behavior</a> of each respective axis should be considered independently.</p>
+   <p>The <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior-x" id="ref-for-propdef-scroll-boundary-behavior-x">scroll-boundary-behavior-x</a> property specifies the behavior of the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior②">scroll-boundary-behavior</a> in the horizontal direction and the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior-y" id="ref-for-propdef-scroll-boundary-behavior-y">scroll-boundary-behavior-y</a> property specifies the handling of the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior③">scroll-boundary-behavior</a> in the vertical direction. When scrolling is performed along both the horizontal and vertical axes at the same time, the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior④">scroll-boundary-behavior</a> of each respective axis should be considered independently.</p>
    <table class="def propdef" data-link-for-hint="scroll-boundary-behavior">
     <tbody>
      <tr>
@@ -1491,13 +1496,13 @@ document but does not want to prevent native overscroll affordances.
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scroll-boundary-behavior">scroll-boundary-behavior</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod"><span class="css">contain</span> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <span class="css">none</span> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one">|</a> <a class="css" data-link-type="maybe" href="#valdef-scroll-boundary-behavior-auto" id="ref-for-valdef-scroll-boundary-behavior-auto-3">auto</a>
+      <td class="prod">contain <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one②">|</a> none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one③">|</a> auto
      <tr>
       <th>Initial:
-      <td><a class="css" data-link-type="maybe" href="#valdef-scroll-boundary-behavior-auto" id="ref-for-valdef-scroll-boundary-behavior-auto-4">auto</a>
+      <td>auto
      <tr>
       <th>Applies to:
-      <td><a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container">scroll container</a> elements
+      <td><a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①⑤">scroll container</a> elements
      <tr>
       <th>Inherited:
       <td>no
@@ -1519,15 +1524,20 @@ document but does not want to prevent native overscroll affordances.
    </table>
    <p>Values have the following meanings:</p>
    <dl>
-    <dt><dfn class="css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-contain">contain<a class="self-link" href="#valdef-scroll-boundary-behavior-contain"></a></dfn> 
-    <dd> This value indicates that the element must not perform <a data-link-type="dfn" href="#non-local-boundary-default-action" id="ref-for-non-local-boundary-default-action-1">non-local boundary default actions</a>. The user agent must not perform scholl chaining to any ancestors along the scroll chain regardless of whether the scroll originated at this element or one of its descendants. This value must not modify the behavior of how <a data-link-type="dfn" href="#local" id="ref-for-local-1">local boundary default actions</a> should behave, such as overscroll behavior and navigation guestures. 
+    <dt><dfn class="dfn-paneled css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-contain">contain</dfn> 
+    <dd> This value indicates that the element must not perform <a data-link-type="dfn" href="#non-local-boundary-default-action" id="ref-for-non-local-boundary-default-action">non-local boundary default actions</a> such as scroll chaining or navigation. The user agent must not perform scroll chaining to any
+    ancestors along the <a data-link-type="dfn" href="#scroll-chain" id="ref-for-scroll-chain②">scroll chain</a> regardless of whether the scroll originated at this
+    element or one of its descendants. This value must not modify the behavior of how <a data-link-type="dfn" href="#local-boundary-default-action" id="ref-for-local-boundary-default-action">local
+    boundary default actions</a> should behave, such as overscroll behavior. 
     <dt><dfn class="css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-none">none<a class="self-link" href="#valdef-scroll-boundary-behavior-none"></a></dfn> 
-    <dd> This value implies the same behavior as <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> and in addition this element must also not perform <a data-link-type="dfn" href="#local" id="ref-for-local-2">local boundary default actions</a> such as showing any overscroll affordances or performing any navigation guestures. 
-    <dt><dfn class="dfn-paneled css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-auto">auto</dfn> 
-    <dd> This value indicates that the user agent should perform the usual <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action-4">boundary default action</a> with respect to both <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining-3">scroll chaining</a>, overscroll and navigation guestures. 
+    <dd> This value implies the same behavior as <a class="css" data-link-type="value" href="#valdef-scroll-boundary-behavior-contain" id="ref-for-valdef-scroll-boundary-behavior-contain">contain</a> and in
+    addition this element must also not perform <a data-link-type="dfn" href="#local-boundary-default-action" id="ref-for-local-boundary-default-action①">local boundary default actions</a> such as
+    showing any overscroll affordances. 
+    <dt><dfn class="css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-auto">auto<a class="self-link" href="#valdef-scroll-boundary-behavior-auto"></a></dfn> 
+    <dd> This value indicates that the user agent should perform the usual <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action④">boundary default action</a> with respect to <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining②">scroll chaining</a>, overscroll and navigation gestures. 
    </dl>
    <p class="note" role="note"><span>Note:</span> In the case where a user agent does not implement scroll chaining and overscroll affordances, these values will have no side effects for a compliant implementation.</p>
-   <p class="note" role="note"><span>Note:</span> Programmatic scrolling is clamped and can not trigger any <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action-5">boundary default actions</a>.</p>
+   <p class="note" role="note"><span>Note:</span> Programmatic scrolling is clamped and can not trigger any <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action⑤">boundary default actions</a>.</p>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -1681,7 +1691,7 @@ document but does not want to prevent native overscroll affordances.
    <li><a href="#valdef-scroll-boundary-behavior-auto">auto</a><span>, in §4</span>
    <li><a href="#boundary-default-action">Boundary default action</a><span>, in §2</span>
    <li><a href="#valdef-scroll-boundary-behavior-contain">contain</a><span>, in §4</span>
-   <li><a href="#local">local</a><span>, in §2</span>
+   <li><a href="#local-boundary-default-action">local boundary default action</a><span>, in §2</span>
    <li><a href="#valdef-scroll-boundary-behavior-none">none</a><span>, in §4</span>
    <li><a href="#non-local-boundary-default-action">non-local boundary default action</a><span>, in §2</span>
    <li><a href="#scroll-boundary">Scroll boundary</a><span>, in §2</span>
@@ -1700,14 +1710,9 @@ document but does not want to prevent native overscroll affordances.
      <li><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">scrollport</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[css-values-3]</a> defines the following terms:
+    <a data-link-type="biblio">[css-values-4]</a> defines the following terms:
     <ul>
      <li><a href="https://drafts.csswg.org/css-values-4/#comb-one">|</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
-    <ul>
-     <li><a href="https://infra.spec.whatwg.org/#list-contain">contain</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -1715,10 +1720,6 @@ document but does not want to prevent native overscroll affordances.
   <dl>
    <dt id="biblio-css-overflow-3">[CSS-OVERFLOW-3]
    <dd>David Baron; Florian Rivoal. <a href="https://www.w3.org/TR/css-overflow-3/">CSS Overflow Module Level 3</a>. URL: <a href="https://www.w3.org/TR/css-overflow-3/">https://www.w3.org/TR/css-overflow-3/</a>
-   <dt id="biblio-css-values-3">[CSS-VALUES-3]
-   <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units Module Level 3</a>. URL: <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a>
-   <dt id="biblio-infra">[INFRA]
-   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
   </dl>
@@ -1739,29 +1740,7 @@ document but does not want to prevent native overscroll affordances.
       <th scope="col">Com­puted value
     <tbody>
      <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior-x">scroll-boundary-behavior-x</a>
-      <td>contain | none | auto
-      <td>auto
-      <td>scroll container elements
-      <td>no
-      <td>N/A
-      <td>visual
-      <td>no
-      <td>per grammar
-      <td>see individual properties
-     <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior-y">scroll-boundary-behavior-y</a>
-      <td>contain | none | auto
-      <td>auto
-      <td>scroll container elements
-      <td>no
-      <td>N/A
-      <td>visual
-      <td>no
-      <td>per grammar
-      <td>see individual properties
-     <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior">scroll-boundary-behavior</a>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior⑤">scroll-boundary-behavior</a>
       <td>contain | none | auto
       <td>auto
       <td>scroll container elements
@@ -1771,70 +1750,94 @@ document but does not want to prevent native overscroll affordances.
       <td>no
       <td>per grammar
       <td>see individual properties
+     <tr>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior-x" id="ref-for-propdef-scroll-boundary-behavior-x①">scroll-boundary-behavior-x</a>
+      <td>contain | none | auto
+      <td>auto
+      <td>scroll container elements
+      <td>no
+      <td>N/A
+      <td>visual
+      <td>no
+      <td>per grammar
+      <td>see individual properties
+     <tr>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior-y" id="ref-for-propdef-scroll-boundary-behavior-y①">scroll-boundary-behavior-y</a>
+      <td>contain | none | auto
+      <td>auto
+      <td>scroll container elements
+      <td>no
+      <td>N/A
+      <td>visual
+      <td>no
+      <td>per grammar
+      <td>see individual properties
    </table>
   </div>
   <aside class="dfn-panel" data-for="scroll-chaining">
    <b><a href="#scroll-chaining">#scroll-chaining</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-chaining-1">1. Introduction</a> <a href="#ref-for-scroll-chaining-2">(2)</a>
-    <li><a href="#ref-for-scroll-chaining-3">4. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-scroll-chaining">1. Introduction</a> <a href="#ref-for-scroll-chaining①">(2)</a>
+    <li><a href="#ref-for-scroll-chaining②">4. Scroll Boundary Behavior Properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="scroll-chain">
    <b><a href="#scroll-chain">#scroll-chain</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-chain-1">1. Introduction</a>
-    <li><a href="#ref-for-scroll-chain-2">2. Scroll chaining and boundary default actions</a>
+    <li><a href="#ref-for-scroll-chain">1. Introduction</a>
+    <li><a href="#ref-for-scroll-chain①">2. Scroll chaining and boundary default actions</a>
+    <li><a href="#ref-for-scroll-chain②">4. Scroll Boundary Behavior Properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="scroll-boundary">
    <b><a href="#scroll-boundary">#scroll-boundary</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-boundary-1">1. Introduction</a>
+    <li><a href="#ref-for-scroll-boundary">1. Introduction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="boundary-default-action">
    <b><a href="#boundary-default-action">#boundary-default-action</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-boundary-default-action-1">1. Introduction</a> <a href="#ref-for-boundary-default-action-2">(2)</a>
-    <li><a href="#ref-for-boundary-default-action-3">2. Scroll chaining and boundary default actions</a>
-    <li><a href="#ref-for-boundary-default-action-4">4. Scroll Boundary Behavior Properties</a> <a href="#ref-for-boundary-default-action-5">(2)</a>
+    <li><a href="#ref-for-boundary-default-action①">1. Introduction</a> <a href="#ref-for-boundary-default-action②">(2)</a>
+    <li><a href="#ref-for-boundary-default-action③">2. Scroll chaining and boundary default actions</a>
+    <li><a href="#ref-for-boundary-default-action④">4. Scroll Boundary Behavior Properties</a> <a href="#ref-for-boundary-default-action⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local">
-   <b><a href="#local">#local</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="local-boundary-default-action">
+   <b><a href="#local-boundary-default-action">#local-boundary-default-action</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-local-1">4. Scroll Boundary Behavior Properties</a> <a href="#ref-for-local-2">(2)</a>
+    <li><a href="#ref-for-local-boundary-default-action">4. Scroll Boundary Behavior Properties</a> <a href="#ref-for-local-boundary-default-action①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="non-local-boundary-default-action">
    <b><a href="#non-local-boundary-default-action">#non-local-boundary-default-action</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-non-local-boundary-default-action-1">4. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-non-local-boundary-default-action">4. Scroll Boundary Behavior Properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-scroll-boundary-behavior-x">
    <b><a href="#propdef-scroll-boundary-behavior-x">#propdef-scroll-boundary-behavior-x</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-scroll-boundary-behavior-x-1">4. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-propdef-scroll-boundary-behavior-x">4. Scroll Boundary Behavior Properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-scroll-boundary-behavior-y">
    <b><a href="#propdef-scroll-boundary-behavior-y">#propdef-scroll-boundary-behavior-y</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-scroll-boundary-behavior-y-1">4. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-propdef-scroll-boundary-behavior-y">4. Scroll Boundary Behavior Properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-scroll-boundary-behavior">
    <b><a href="#propdef-scroll-boundary-behavior">#propdef-scroll-boundary-behavior</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-scroll-boundary-behavior-1">4. Scroll Boundary Behavior Properties</a> <a href="#ref-for-propdef-scroll-boundary-behavior-2">(2)</a> <a href="#ref-for-propdef-scroll-boundary-behavior-3">(3)</a>
+    <li><a href="#ref-for-propdef-scroll-boundary-behavior①">1. Introduction</a>
+    <li><a href="#ref-for-propdef-scroll-boundary-behavior②">4. Scroll Boundary Behavior Properties</a> <a href="#ref-for-propdef-scroll-boundary-behavior③">(2)</a> <a href="#ref-for-propdef-scroll-boundary-behavior④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-boundary-behavior-auto">
-   <b><a href="#valdef-scroll-boundary-behavior-auto">#valdef-scroll-boundary-behavior-auto</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="valdef-scroll-boundary-behavior-contain">
+   <b><a href="#valdef-scroll-boundary-behavior-contain">#valdef-scroll-boundary-behavior-contain</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-scroll-boundary-behavior-auto-1">4. Scroll Boundary Behavior Properties</a> <a href="#ref-for-valdef-scroll-boundary-behavior-auto-2">(2)</a> <a href="#ref-for-valdef-scroll-boundary-behavior-auto-3">(3)</a> <a href="#ref-for-valdef-scroll-boundary-behavior-auto-4">(4)</a>
+    <li><a href="#ref-for-valdef-scroll-boundary-behavior-contain">4. Scroll Boundary Behavior Properties</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -1408,7 +1408,7 @@ such as scroll chaining and overscroll, should not be triggered.</p>
     <li><a href="#scroll-chaining-and-boundary-default-actions"><span class="secno">2</span> <span class="content">Scroll chaining and boundary default actions</span></a>
     <li><a href="#overview"><span class="secno">3</span> <span class="content">Overview</span></a>
     <li><a href="#scroll-boundary-behavior-properties"><span class="secno">4</span> <span class="content">Scroll Boundary Behavior Properties</span></a>
-    <li><a href="#security-and-privacy-considerations"><span class="secno">5</span> <span class="content">Security and Privacy Considerations</span></a>
+    <li><a href="#security-and-privacy"><span class="secno">5</span> <span class="content">Security and Privacy Considerations</span></a>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
@@ -1539,7 +1539,7 @@ navigation action.</p>
    </dl>
    <p class="note" role="note"><span>Note:</span> In the case where a user agent does not implement scroll chaining and overscroll affordances, these values will have no side effects for a compliant implementation.</p>
    <p class="note" role="note"><span>Note:</span> Programmatic scrolling is clamped and can not trigger any <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action⑤">boundary default actions</a>.</p>
-   <h2 class="heading settled" data-level="5" id="security-and-privacy-considerations"><span class="secno">5. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy-considerations"></a></h2>
+   <h2 class="heading settled" data-level="5" id="security-and-privacy"><span class="secno">5. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
     There are no known security or privacy impacts of this feature. The feature may be used to prevent
 certain native UI features such as overscroll affordances and overscroll navigations (e.g., pull-
 to-refresh, swipe navigations). However, this does not expose any additional abilities beyond what


### PR DESCRIPTION
This PR fixes all link warnings reported by bikeshed.

- Close a few open tags
- Define local boundary action directly and remove explicitly linking
them to 'local'
- Avoid auto link in propetydef which causes link issue. Other CSS specs
do it this way as well.
- Make link to 'contain' be specific to the property.