### PR TITLE
Computed value as specified for longhands

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -162,7 +162,7 @@ Applies to: <a>scroll container</a> elements
 Inherited: no
 Percentages: N/A
 Media: visual
-Computed value: see individual properties
+Computed value: as specified
 Animatable: no
 Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
 </pre>

--- a/index.html
+++ b/index.html
@@ -1598,7 +1598,7 @@ use <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-prevent
       <td>visual
      <tr>
       <th>Computed value:
-      <td>see individual properties
+      <td>as specified
      <tr>
       <th>Canonical order:
       <td><abbr title="follows order of property value definition">per grammar</abbr>
@@ -1888,7 +1888,7 @@ cause a scroll.
       <td>visual
       <td>no
       <td>per grammar
-      <td>see individual properties
+      <td>as specified
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior-y" id="ref-for-propdef-scroll-boundary-behavior-y①">scroll-boundary-behavior-y</a>
       <td>contain | none | auto
@@ -1899,7 +1899,7 @@ cause a scroll.
       <td>visual
       <td>no
       <td>per grammar
-      <td>see individual properties
+      <td>as specified
    </table>
   </div>
   <aside class="dfn-panel" data-for="scroll-chaining">


### PR DESCRIPTION
scroll-boundary-behavior-x and scroll-boundary-behavior-y
are longhand properties that accept keyword values
(contain | none | auto).

The computed value should be as specified.

'Computed value: see individual properties' only makes sense
for shorthand properties, not longhands.