### PR TITLE
Shorthand syntax when -x and -y values distinct

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -175,8 +175,8 @@ axis should be considered independently.
 
 <pre class=propdef>
 Name: scroll-boundary-behavior
-Value: contain | none | auto
-Initial: auto
+Value: [ contain | none | auto ]{1,2}
+Initial: auto auto
 Applies to: <a>scroll container</a> elements
 Inherited: no
 Media: visual
@@ -184,6 +184,8 @@ Computed value: see individual properties
 Animatable: no
 Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
 </pre>
+
+The two values specify the behavior in the horizontal and vertical direction, respectively. If only one value is specified, the second value defaults to the same value.
 
 Values have the following meanings:
 

--- a/index.html
+++ b/index.html
@@ -1617,10 +1617,10 @@ axis should be considered independently.</p>
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scroll-boundary-behavior">scroll-boundary-behavior</dfn>
      <tr class="value">
       <th>Value:
-      <td class="prod">contain <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one②">|</a> none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one③">|</a> auto
+      <td class="prod">[ contain <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one②">|</a> none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one③">|</a> auto ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-num-range" id="ref-for-mult-num-range">{1,2}</a>
      <tr>
       <th>Initial:
-      <td>auto
+      <td>auto auto
      <tr>
       <th>Applies to:
       <td><a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①⑤">scroll container</a> elements
@@ -1643,6 +1643,7 @@ axis should be considered independently.</p>
       <th>Animatable:
       <td>no
    </table>
+   <p>The two values specify the behavior in the horizontal and vertical direction, respectively. If only one value is specified, the second value defaults to the same value.</p>
    <p>Values have the following meanings:</p>
    <dl>
     <dt><dfn class="dfn-paneled css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-contain">contain</dfn> 
@@ -1840,6 +1841,7 @@ cause a scroll.
    <li>
     <a data-link-type="biblio">[css-values-4]</a> defines the following terms:
     <ul>
+     <li><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">{a,b}</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#comb-one">|</a>
     </ul>
   </ul>
@@ -1869,8 +1871,8 @@ cause a scroll.
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior⑤">scroll-boundary-behavior</a>
-      <td>contain | none | auto
-      <td>auto
+      <td>[ contain | none | auto ]{1,2}
+      <td>auto auto
       <td>scroll container elements
       <td>no
       <td>n/a


### PR DESCRIPTION
The syntax for scroll-boundary-behavior did not support distinct
values for scroll-boundary-behavior-x and scroll-boundary-behavior-y.

resolves #18