### PR TITLE
Rename scroll-boundary-behavior to overscroll-behavior

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
-Title: CSS Scroll Boundary Behavior Module Level 1
-Shortname: scroll-boundary-behavior
+Title: CSS Overscroll Behavior Module Level 1
+Shortname: overscroll-behavior
 Level: 1
 Status: CG-DRAFT
 Work Status: Exploring
@@ -8,7 +8,7 @@ Group: WICG
 URL: https://wicg.github.io/scroll-boundary-behavior/
 Repository: wicg/scroll-boundary-behavior
 Editor: Benoit Girard, Facebook, bgirard@fb.com
-Abstract: This module defines 'scroll-boundary-behavior' to control the behavior when the scroll position of a <a>scroll container</a> reaches the edge of the <a>scrollport</a>.
+Abstract: This module defines 'overscroll-behavior' to control the behavior when the scroll position of a <a>scroll container</a> reaches the edge of the <a>scrollport</a>.
 Abstract: This allows content authors to hint that the <a>boundary default actions</a>,
 Abstract: such as scroll chaining and overscroll, should not be triggered.
 </pre>
@@ -55,7 +55,7 @@ chaining will occur. This is detrimental for the following reasons:
     content author to cancel only some of the <a>default actions</a> such as scroll chaining.
 
 Thus, it is not possible for a content author to control <a>scroll chaining</a> and overscroll in a
-robust, performant and forward compatible way. The 'scroll-boundary-behavior' property fixes this
+robust, performant and forward compatible way. The 'overscroll-behavior' property fixes this
 shortcoming.
 
 
@@ -71,11 +71,11 @@ prevented.
 
   <pre class="lang-css">
   #sidebar {
-    scroll-boundary-behavior: contain;
+    overscroll-behavior: contain;
   }
   </pre>
 
-In this case, the author can use <a value for=scroll-boundary-behavior>contain</a> on the sidebar to
+In this case, the author can use <a value for=overscroll-behavior>contain</a> on the sidebar to
 prevent scrolling from being chained to the parent document element.
 </div>
 
@@ -86,11 +86,11 @@ native overscroll action.
   <pre class="lang-css">
   html {
     /* only disable pull-to-refresh but allow swipe navigations */
-    scroll-boundary-behavior-y: contain;
+    overscroll-behavior-y: contain;
   }
   </pre>
 
-In this case, the author can use <a value for=scroll-boundary-behavior>contain</a> on the viewport
+In this case, the author can use <a value for=overscroll-behavior>contain</a> on the viewport
 defining element to prevent overscroll from triggering navigation actions.
 </div>
 
@@ -100,11 +100,11 @@ potentially confusing rubber banding effect in addition to scroll chaining.
 
   <pre class="lang-css">
   #infinite_scroller {
-    scroll-boundary-behavior-y: none;
+    overscroll-behavior-y: none;
   }
   </pre>
 
-In this case the the author can use <a value for=scroll-boundary-behavior>none</a> on the infinite
+In this case the the author can use <a value for=overscroll-behavior>none</a> on the infinite
 scroller to prevent both scroll chaining and overscroll affordance.
 </div>
 
@@ -144,7 +144,7 @@ This module introduces control over the behavior of a <a>scroll container</a> el
 <a>scrollport</a> reaches the boundary of its scroll box. It allows the content author to specify
 that a <a>scroll container</a> element must prevent scroll chaining and/or overscroll affordances.
 
-Scroll Boundary Behavior Properties {#scroll-boundary-behavior-properties}
+Overscroll Behavior Properties {#overscroll-behavior-properties}
 ==========================
 
 These properties specify how a <a>scroll container</a> element must behave when scrolling. A element
@@ -156,7 +156,7 @@ for preventing both scroll chaining and overscroll. Doing otherwise would cause 
 use <a>preventDefault</a> instead.
 
 <pre class=propdef>
-Name: scroll-boundary-behavior-x, scroll-boundary-behavior-y
+Name: overscroll-behavior-x, overscroll-behavior-y
 Value: contain | none | auto
 Initial: auto
 Applies to: <a>scroll container</a> elements
@@ -168,14 +168,14 @@ Animatable: no
 Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
 </pre>
 
-The 'scroll-boundary-behavior-x' property specifies the behavior of the 'scroll-boundary-behavior'
-in the horizontal direction and the 'scroll-boundary-behavior-y' property specifies the handling of
-the 'scroll-boundary-behavior' in the vertical direction. When scrolling is performed along both the
-horizontal and vertical axes at the same time, the 'scroll-boundary-behavior' of each respective
+The 'overscroll-behavior-x' property specifies the behavior of the 'overscroll-behavior'
+in the horizontal direction and the 'overscroll-behavior-y' property specifies the handling of
+the 'overscroll-behavior' in the vertical direction. When scrolling is performed along both the
+horizontal and vertical axes at the same time, the 'overscroll-behavior' of each respective
 axis should be considered independently.
 
 <pre class=propdef>
-Name: scroll-boundary-behavior
+Name: overscroll-behavior
 Value: [ contain | none | auto ]{1,2}
 Initial: auto auto
 Applies to: <a>scroll container</a> elements
@@ -190,7 +190,7 @@ The two values specify the behavior in the horizontal and vertical direction, re
 
 Values have the following meanings:
 
-<dl dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" dfn-type="value">
+<dl dfn-for="overscroll-behavior, overscroll-behavior-x, overscroll-behavior-y" dfn-type="value">
   <dt><dfn>contain</dfn>
   <dd>
     This value indicates that the element must not perform <a>non-local boundary default actions</a>
@@ -200,7 +200,7 @@ Values have the following meanings:
     boundary default actions</a> should behave, such as overscroll behavior.
   <dt><dfn>none</dfn>
   <dd>
-    This value implies the same behavior as <a value for=scroll-boundary-behavior>contain</a> and in
+    This value implies the same behavior as <a value for=overscroll-behavior>contain</a> and in
     addition this element must also not perform <a>local boundary default actions</a> such as
     showing any overscroll affordances.
   <dt><dfn>auto</dfn>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-  <title>CSS Scroll Boundary Behavior Module Level 1</title>
+  <title>CSS Overscroll Behavior Module Level 1</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
 <style data-fill-with="stylesheet">/******************************************************************************
  *                   Style sheet for the W3C specifications                   *
@@ -1423,8 +1423,8 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"></p>
-   <h1 class="p-name no-ref" id="title">CSS Scroll Boundary Behavior Module Level 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-12">12 October 2017</time></span></h2>
+   <h1 class="p-name no-ref" id="title">CSS Overscroll Behavior Module Level 1</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-24">24 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1436,13 +1436,13 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 the Contributors to the CSS Scroll Boundary Behavior Module Level 1 Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 the Contributors to the CSS Overscroll Behavior Module Level 1 Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
 A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>This module defines <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior">scroll-boundary-behavior</a> to control the behavior when the scroll position of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container">scroll container</a> reaches the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport">scrollport</a>.
+   <p>This module defines <a class="property" data-link-type="propdesc" href="#propdef-overscroll-behavior" id="ref-for-propdef-overscroll-behavior">overscroll-behavior</a> to control the behavior when the scroll position of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container">scroll container</a> reaches the edge of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport">scrollport</a>.
 
 This allows content authors to hint that the <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action">boundary default actions</a>,
 such as scroll chaining and overscroll, should not be triggered.</p>
@@ -1466,7 +1466,7 @@ such as scroll chaining and overscroll, should not be triggered.</p>
     <li><a href="#motivating-examples"><span class="secno">2</span> <span class="content">Motivating Examples</span></a>
     <li><a href="#scroll-chaining-and-boundary-default-actions"><span class="secno">3</span> <span class="content">Scroll chaining and boundary default actions</span></a>
     <li><a href="#overview"><span class="secno">4</span> <span class="content">Overview</span></a>
-    <li><a href="#scroll-boundary-behavior-properties"><span class="secno">5</span> <span class="content">Scroll Boundary Behavior Properties</span></a>
+    <li><a href="#overscroll-behavior-properties"><span class="secno">5</span> <span class="content">Overscroll Behavior Properties</span></a>
     <li><a href="#security-and-privacy"><span class="secno">6</span> <span class="content">Security and Privacy Considerations</span></a>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
@@ -1509,40 +1509,40 @@ not want to cancel such as an overscroll affordance. <a data-link-type="dfn" hre
 content author to cancel only some of the <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#default-action" id="ref-for-default-action②">default actions</a> such as scroll chaining.</p>
    </ul>
    <p>Thus, it is not possible for a content author to control <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining①">scroll chaining</a> and overscroll in a
-robust, performant and forward compatible way. The <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior①">scroll-boundary-behavior</a> property fixes this
+robust, performant and forward compatible way. The <a class="property" data-link-type="propdesc" href="#propdef-overscroll-behavior" id="ref-for-propdef-overscroll-behavior①">overscroll-behavior</a> property fixes this
 shortcoming.</p>
    <h2 class="heading settled" data-level="2" id="motivating-examples"><span class="secno">2. </span><span class="content">Motivating Examples</span><a class="self-link" href="#motivating-examples"></a></h2>
-   <div class="example" id="example-a1f5ebb4">
-    <a class="self-link" href="#example-a1f5ebb4"></a> A position fixed left navigation bar does not want to hand off scrolling to the document because a
+   <div class="example" id="example-5e7ee93b">
+    <a class="self-link" href="#example-5e7ee93b"></a> A position fixed left navigation bar does not want to hand off scrolling to the document because a
 scroll gesture performed on the navigation bar is almost never meant to scroll the document. Note
 that using the native overscroll affordances are still desirable while scroll chaining is to be
 prevented. 
 <pre class="lang-css highlight"><span class="nt">#sidebar </span><span class="p">{</span>
-  <span class="k">scroll-boundary-behavior</span><span class="p">:</span> contain<span class="p">;</span>
+  <span class="k">overscroll-behavior</span><span class="p">:</span> contain<span class="p">;</span>
 <span class="p">}</span>
 </pre>
-    <p>In this case, the author can use <a class="css" data-link-type="value" href="#valdef-scroll-boundary-behavior-contain" id="ref-for-valdef-scroll-boundary-behavior-contain">contain</a> on the sidebar to
+    <p>In this case, the author can use <a class="css" data-link-type="value" href="#valdef-overscroll-behavior-contain" id="ref-for-valdef-overscroll-behavior-contain">contain</a> on the sidebar to
 prevent scrolling from being chained to the parent document element.</p>
    </div>
-   <div class="example" id="example-c6c2fc68">
-    <a class="self-link" href="#example-c6c2fc68"></a> A page wants to implement their own pull-to-refresh effect and thus needs to disable browser
+   <div class="example" id="example-d6b56a03">
+    <a class="self-link" href="#example-d6b56a03"></a> A page wants to implement their own pull-to-refresh effect and thus needs to disable browser
 native overscroll action. 
 <pre class="lang-css highlight"><span class="nt">html </span><span class="p">{</span>
   <span class="c">/* only disable pull-to-refresh but allow swipe navigations */</span>
-  <span class="k">scroll-boundary-behavior-y</span><span class="p">:</span> contain<span class="p">;</span>
+  <span class="k">overscroll-behavior-y</span><span class="p">:</span> contain<span class="p">;</span>
 <span class="p">}</span>
 </pre>
-    <p>In this case, the author can use <a class="css" data-link-type="value" href="#valdef-scroll-boundary-behavior-contain" id="ref-for-valdef-scroll-boundary-behavior-contain①">contain</a> on the viewport
+    <p>In this case, the author can use <a class="css" data-link-type="value" href="#valdef-overscroll-behavior-contain" id="ref-for-valdef-overscroll-behavior-contain①">contain</a> on the viewport
 defining element to prevent overscroll from triggering navigation actions.</p>
    </div>
-   <div class="example" id="example-0c813283">
-    <a class="self-link" href="#example-0c813283"></a> A infinite scrollers loads more content as user reaches the boundary and thus wants to disable the
+   <div class="example" id="example-1a411b79">
+    <a class="self-link" href="#example-1a411b79"></a> A infinite scrollers loads more content as user reaches the boundary and thus wants to disable the
 potentially confusing rubber banding effect in addition to scroll chaining. 
 <pre class="lang-css highlight"><span class="nt">#infinite_scroller </span><span class="p">{</span>
-  <span class="k">scroll-boundary-behavior-y</span><span class="p">:</span> none<span class="p">;</span>
+  <span class="k">overscroll-behavior-y</span><span class="p">:</span> none<span class="p">;</span>
 <span class="p">}</span>
 </pre>
-    <p>In this case the the author can use <a class="css" data-link-type="value" href="#valdef-scroll-boundary-behavior-none" id="ref-for-valdef-scroll-boundary-behavior-none">none</a> on the infinite
+    <p>In this case the the author can use <a class="css" data-link-type="value" href="#valdef-overscroll-behavior-none" id="ref-for-valdef-overscroll-behavior-none">none</a> on the infinite
 scroller to prevent both scroll chaining and overscroll affordance.</p>
    </div>
    <h2 class="heading settled" data-level="3" id="scroll-chaining-and-boundary-default-actions"><span class="secno">3. </span><span class="content">Scroll chaining and boundary default actions</span><a class="self-link" href="#scroll-chaining-and-boundary-default-actions"></a></h2>
@@ -1567,17 +1567,17 @@ navigation action.</p>
    <h2 class="heading settled" data-level="4" id="overview"><span class="secno">4. </span><span class="content">Overview</span><a class="self-link" href="#overview"></a></h2>
    <p>This module introduces control over the behavior of a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①⓪">scroll container</a> element when its <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scrollport" id="ref-for-scrollport⑤">scrollport</a> reaches the boundary of its scroll box. It allows the content author to specify
 that a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①①">scroll container</a> element must prevent scroll chaining and/or overscroll affordances.</p>
-   <h2 class="heading settled" data-level="5" id="scroll-boundary-behavior-properties"><span class="secno">5. </span><span class="content">Scroll Boundary Behavior Properties</span><a class="self-link" href="#scroll-boundary-behavior-properties"></a></h2>
+   <h2 class="heading settled" data-level="5" id="overscroll-behavior-properties"><span class="secno">5. </span><span class="content">Overscroll Behavior Properties</span><a class="self-link" href="#overscroll-behavior-properties"></a></h2>
    <p>These properties specify how a <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①②">scroll container</a> element must behave when scrolling. A element
 that is not <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#scroll-container" id="ref-for-scroll-container①③">scroll container</a> must accept but ignore the values of this property. This
 property must be applied to all input methods supported by the user agent.</p>
    <p class="note" role="note"><span>Note:</span> This property should provide guarantees that are, at least, as strong as <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault④">preventDefault</a> for preventing both scroll chaining and overscroll. Doing otherwise would cause content authors to
 use <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault⑤">preventDefault</a> instead.</p>
-   <table class="def propdef" data-link-for-hint="scroll-boundary-behavior-x">
+   <table class="def propdef" data-link-for-hint="overscroll-behavior-x">
     <tbody>
      <tr>
       <th>Name:
-      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scroll-boundary-behavior-x">scroll-boundary-behavior-x</dfn>, <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scroll-boundary-behavior-y">scroll-boundary-behavior-y</dfn>
+      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-overscroll-behavior-x">overscroll-behavior-x</dfn>, <dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-overscroll-behavior-y">overscroll-behavior-y</dfn>
      <tr class="value">
       <th>Value:
       <td class="prod">contain <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①">|</a> auto
@@ -1606,15 +1606,15 @@ use <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-prevent
       <th>Animatable:
       <td>no
    </table>
-   <p>The <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior-x" id="ref-for-propdef-scroll-boundary-behavior-x">scroll-boundary-behavior-x</a> property specifies the behavior of the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior②">scroll-boundary-behavior</a> in the horizontal direction and the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior-y" id="ref-for-propdef-scroll-boundary-behavior-y">scroll-boundary-behavior-y</a> property specifies the handling of
-the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior③">scroll-boundary-behavior</a> in the vertical direction. When scrolling is performed along both the
-horizontal and vertical axes at the same time, the <a class="property" data-link-type="propdesc" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior④">scroll-boundary-behavior</a> of each respective
+   <p>The <a class="property" data-link-type="propdesc" href="#propdef-overscroll-behavior-x" id="ref-for-propdef-overscroll-behavior-x">overscroll-behavior-x</a> property specifies the behavior of the <a class="property" data-link-type="propdesc" href="#propdef-overscroll-behavior" id="ref-for-propdef-overscroll-behavior②">overscroll-behavior</a> in the horizontal direction and the <a class="property" data-link-type="propdesc" href="#propdef-overscroll-behavior-y" id="ref-for-propdef-overscroll-behavior-y">overscroll-behavior-y</a> property specifies the handling of
+the <a class="property" data-link-type="propdesc" href="#propdef-overscroll-behavior" id="ref-for-propdef-overscroll-behavior③">overscroll-behavior</a> in the vertical direction. When scrolling is performed along both the
+horizontal and vertical axes at the same time, the <a class="property" data-link-type="propdesc" href="#propdef-overscroll-behavior" id="ref-for-propdef-overscroll-behavior④">overscroll-behavior</a> of each respective
 axis should be considered independently.</p>
-   <table class="def propdef" data-link-for-hint="scroll-boundary-behavior">
+   <table class="def propdef" data-link-for-hint="overscroll-behavior">
     <tbody>
      <tr>
       <th>Name:
-      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-scroll-boundary-behavior">scroll-boundary-behavior</dfn>
+      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export="" id="propdef-overscroll-behavior">overscroll-behavior</dfn>
      <tr class="value">
       <th>Value:
       <td class="prod">[ contain <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one②">|</a> none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one③">|</a> auto ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-num-range" id="ref-for-mult-num-range">{1,2}</a>
@@ -1646,16 +1646,16 @@ axis should be considered independently.</p>
    <p>The two values specify the behavior in the horizontal and vertical direction, respectively. If only one value is specified, the second value defaults to the same value.</p>
    <p>Values have the following meanings:</p>
    <dl>
-    <dt><dfn class="dfn-paneled css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-contain">contain</dfn> 
+    <dt><dfn class="dfn-paneled css" data-dfn-for="overscroll-behavior, overscroll-behavior-x, overscroll-behavior-y" data-dfn-type="value" data-export="" id="valdef-overscroll-behavior-contain">contain</dfn> 
     <dd> This value indicates that the element must not perform <a data-link-type="dfn" href="#non-local-boundary-default-action" id="ref-for-non-local-boundary-default-action">non-local boundary default actions</a> such as scroll chaining or navigation. The user agent must not perform scroll chaining to any
     ancestors along the <a data-link-type="dfn" href="#scroll-chain" id="ref-for-scroll-chain②">scroll chain</a> regardless of whether the scroll originated at this
     element or one of its descendants. This value must not modify the behavior of how <a data-link-type="dfn" href="#local-boundary-default-action" id="ref-for-local-boundary-default-action">local
     boundary default actions</a> should behave, such as overscroll behavior. 
-    <dt><dfn class="dfn-paneled css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-none">none</dfn> 
-    <dd> This value implies the same behavior as <a class="css" data-link-type="value" href="#valdef-scroll-boundary-behavior-contain" id="ref-for-valdef-scroll-boundary-behavior-contain②">contain</a> and in
+    <dt><dfn class="dfn-paneled css" data-dfn-for="overscroll-behavior, overscroll-behavior-x, overscroll-behavior-y" data-dfn-type="value" data-export="" id="valdef-overscroll-behavior-none">none</dfn> 
+    <dd> This value implies the same behavior as <a class="css" data-link-type="value" href="#valdef-overscroll-behavior-contain" id="ref-for-valdef-overscroll-behavior-contain②">contain</a> and in
     addition this element must also not perform <a data-link-type="dfn" href="#local-boundary-default-action" id="ref-for-local-boundary-default-action①">local boundary default actions</a> such as
     showing any overscroll affordances. 
-    <dt><dfn class="css" data-dfn-for="scroll-boundary-behavior, scroll-boundary-behavior-x, scroll-boundary-behavior-y" data-dfn-type="value" data-export="" id="valdef-scroll-boundary-behavior-auto">auto<a class="self-link" href="#valdef-scroll-boundary-behavior-auto"></a></dfn> 
+    <dt><dfn class="css" data-dfn-for="overscroll-behavior, overscroll-behavior-x, overscroll-behavior-y" data-dfn-type="value" data-export="" id="valdef-overscroll-behavior-auto">auto<a class="self-link" href="#valdef-overscroll-behavior-auto"></a></dfn> 
     <dd> This value indicates that the user agent should perform the usual <a data-link-type="dfn" href="#boundary-default-action" id="ref-for-boundary-default-action④">boundary default action</a> with respect to <a data-link-type="dfn" href="#scroll-chaining" id="ref-for-scroll-chaining②">scroll chaining</a>, overscroll and navigation gestures. 
    </dl>
    <p class="note" role="note"><span>Note:</span> In the case where a user agent does not implement scroll chaining and overscroll affordances,
@@ -1817,16 +1817,16 @@ cause a scroll.
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#valdef-scroll-boundary-behavior-auto">auto</a><span>, in §5</span>
+   <li><a href="#valdef-overscroll-behavior-auto">auto</a><span>, in §5</span>
    <li><a href="#boundary-default-action">Boundary default action</a><span>, in §3</span>
-   <li><a href="#valdef-scroll-boundary-behavior-contain">contain</a><span>, in §5</span>
+   <li><a href="#valdef-overscroll-behavior-contain">contain</a><span>, in §5</span>
    <li><a href="#local-boundary-default-action">local boundary default action</a><span>, in §3</span>
-   <li><a href="#valdef-scroll-boundary-behavior-none">none</a><span>, in §5</span>
+   <li><a href="#valdef-overscroll-behavior-none">none</a><span>, in §5</span>
    <li><a href="#non-local-boundary-default-action">non-local boundary default action</a><span>, in §3</span>
+   <li><a href="#propdef-overscroll-behavior">overscroll-behavior</a><span>, in §5</span>
+   <li><a href="#propdef-overscroll-behavior-x">overscroll-behavior-x</a><span>, in §5</span>
+   <li><a href="#propdef-overscroll-behavior-y">overscroll-behavior-y</a><span>, in §5</span>
    <li><a href="#scroll-boundary">Scroll boundary</a><span>, in §3</span>
-   <li><a href="#propdef-scroll-boundary-behavior">scroll-boundary-behavior</a><span>, in §5</span>
-   <li><a href="#propdef-scroll-boundary-behavior-x">scroll-boundary-behavior-x</a><span>, in §5</span>
-   <li><a href="#propdef-scroll-boundary-behavior-y">scroll-boundary-behavior-y</a><span>, in §5</span>
    <li><a href="#scroll-chain">scroll chain</a><span>, in §3</span>
    <li><a href="#scroll-chaining">Scroll chaining</a><span>, in §3</span>
   </ul>
@@ -1870,7 +1870,7 @@ cause a scroll.
       <th scope="col">Com­puted value
     <tbody>
      <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior" id="ref-for-propdef-scroll-boundary-behavior⑤">scroll-boundary-behavior</a>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-overscroll-behavior" id="ref-for-propdef-overscroll-behavior⑤">overscroll-behavior</a>
       <td>[ contain | none | auto ]{1,2}
       <td>auto auto
       <td>scroll container elements
@@ -1881,7 +1881,7 @@ cause a scroll.
       <td>per grammar
       <td>see individual properties
      <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior-x" id="ref-for-propdef-scroll-boundary-behavior-x①">scroll-boundary-behavior-x</a>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-overscroll-behavior-x" id="ref-for-propdef-overscroll-behavior-x①">overscroll-behavior-x</a>
       <td>contain | none | auto
       <td>auto
       <td>scroll container elements
@@ -1892,7 +1892,7 @@ cause a scroll.
       <td>per grammar
       <td>as specified
      <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-scroll-boundary-behavior-y" id="ref-for-propdef-scroll-boundary-behavior-y①">scroll-boundary-behavior-y</a>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-overscroll-behavior-y" id="ref-for-propdef-overscroll-behavior-y①">overscroll-behavior-y</a>
       <td>contain | none | auto
       <td>auto
       <td>scroll container elements
@@ -1908,7 +1908,7 @@ cause a scroll.
    <b><a href="#scroll-chaining">#scroll-chaining</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-chaining">1. Introduction</a> <a href="#ref-for-scroll-chaining①">(2)</a>
-    <li><a href="#ref-for-scroll-chaining②">5. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-scroll-chaining②">5. Overscroll Behavior Properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="scroll-chain">
@@ -1916,7 +1916,7 @@ cause a scroll.
    <ul>
     <li><a href="#ref-for-scroll-chain">1. Introduction</a>
     <li><a href="#ref-for-scroll-chain①">3. Scroll chaining and boundary default actions</a>
-    <li><a href="#ref-for-scroll-chain②">5. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-scroll-chain②">5. Overscroll Behavior Properties</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="scroll-boundary">
@@ -1930,51 +1930,51 @@ cause a scroll.
    <ul>
     <li><a href="#ref-for-boundary-default-action①">1. Introduction</a> <a href="#ref-for-boundary-default-action②">(2)</a>
     <li><a href="#ref-for-boundary-default-action③">3. Scroll chaining and boundary default actions</a>
-    <li><a href="#ref-for-boundary-default-action④">5. Scroll Boundary Behavior Properties</a> <a href="#ref-for-boundary-default-action⑤">(2)</a>
+    <li><a href="#ref-for-boundary-default-action④">5. Overscroll Behavior Properties</a> <a href="#ref-for-boundary-default-action⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="local-boundary-default-action">
    <b><a href="#local-boundary-default-action">#local-boundary-default-action</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-local-boundary-default-action">5. Scroll Boundary Behavior Properties</a> <a href="#ref-for-local-boundary-default-action①">(2)</a>
+    <li><a href="#ref-for-local-boundary-default-action">5. Overscroll Behavior Properties</a> <a href="#ref-for-local-boundary-default-action①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="non-local-boundary-default-action">
    <b><a href="#non-local-boundary-default-action">#non-local-boundary-default-action</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-non-local-boundary-default-action">5. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-non-local-boundary-default-action">5. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-boundary-behavior-x">
-   <b><a href="#propdef-scroll-boundary-behavior-x">#propdef-scroll-boundary-behavior-x</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="propdef-overscroll-behavior-x">
+   <b><a href="#propdef-overscroll-behavior-x">#propdef-overscroll-behavior-x</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-scroll-boundary-behavior-x">5. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-propdef-overscroll-behavior-x">5. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-boundary-behavior-y">
-   <b><a href="#propdef-scroll-boundary-behavior-y">#propdef-scroll-boundary-behavior-y</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="propdef-overscroll-behavior-y">
+   <b><a href="#propdef-overscroll-behavior-y">#propdef-overscroll-behavior-y</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-scroll-boundary-behavior-y">5. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-propdef-overscroll-behavior-y">5. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-boundary-behavior">
-   <b><a href="#propdef-scroll-boundary-behavior">#propdef-scroll-boundary-behavior</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="propdef-overscroll-behavior">
+   <b><a href="#propdef-overscroll-behavior">#propdef-overscroll-behavior</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-scroll-boundary-behavior①">1. Introduction</a>
-    <li><a href="#ref-for-propdef-scroll-boundary-behavior②">5. Scroll Boundary Behavior Properties</a> <a href="#ref-for-propdef-scroll-boundary-behavior③">(2)</a> <a href="#ref-for-propdef-scroll-boundary-behavior④">(3)</a>
+    <li><a href="#ref-for-propdef-overscroll-behavior①">1. Introduction</a>
+    <li><a href="#ref-for-propdef-overscroll-behavior②">5. Overscroll Behavior Properties</a> <a href="#ref-for-propdef-overscroll-behavior③">(2)</a> <a href="#ref-for-propdef-overscroll-behavior④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-boundary-behavior-contain">
-   <b><a href="#valdef-scroll-boundary-behavior-contain">#valdef-scroll-boundary-behavior-contain</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="valdef-overscroll-behavior-contain">
+   <b><a href="#valdef-overscroll-behavior-contain">#valdef-overscroll-behavior-contain</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-scroll-boundary-behavior-contain">2. Motivating Examples</a> <a href="#ref-for-valdef-scroll-boundary-behavior-contain①">(2)</a>
-    <li><a href="#ref-for-valdef-scroll-boundary-behavior-contain②">5. Scroll Boundary Behavior Properties</a>
+    <li><a href="#ref-for-valdef-overscroll-behavior-contain">2. Motivating Examples</a> <a href="#ref-for-valdef-overscroll-behavior-contain①">(2)</a>
+    <li><a href="#ref-for-valdef-overscroll-behavior-contain②">5. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-boundary-behavior-none">
-   <b><a href="#valdef-scroll-boundary-behavior-none">#valdef-scroll-boundary-behavior-none</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="valdef-overscroll-behavior-none">
+   <b><a href="#valdef-overscroll-behavior-none">#valdef-overscroll-behavior-none</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-scroll-boundary-behavior-none">2. Motivating Examples</a>
+    <li><a href="#ref-for-valdef-overscroll-behavior-none">2. Motivating Examples</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
Replace scroll-boundary-behavior with overscroll behavior. The only exception is in the repo name.
Fixes #24.